### PR TITLE
Add sticky session support to containous/oxy's round robin

### DIFF
--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 )
 
 // RebalancerOption - functional option setter for rebalancer
@@ -48,6 +48,9 @@ type Rebalancer struct {
 
 	// creates new meters
 	newMeter NewMeterFn
+
+	// sticky session object
+	ss *StickySession
 }
 
 func RebalancerLogger(log utils.Logger) RebalancerOption {
@@ -86,10 +89,18 @@ func RebalancerErrorHandler(h utils.ErrorHandler) RebalancerOption {
 	}
 }
 
+func RebalancerStickySession(ss *StickySession) RebalancerOption {
+	return func(r *Rebalancer) error {
+		r.ss = ss
+		return nil
+	}
+}
+
 func NewRebalancer(handler balancerHandler, opts ...RebalancerOption) (*Rebalancer, error) {
 	rb := &Rebalancer{
 		mtx:  &sync.Mutex{},
 		next: handler,
+		ss:   nil,
 	}
 	for _, o := range opts {
 		if err := o(rb); err != nil {
@@ -134,18 +145,41 @@ func (rb *Rebalancer) Servers() []*url.URL {
 func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	pw := &utils.ProxyWriter{W: w}
 	start := rb.clock.UtcNow()
-	url, err := rb.next.NextServer()
-	if err != nil {
-		rb.errHandler.ServeHTTP(w, req, err)
-		return
-	}
 
 	// make shallow copy of request before changing anything to avoid side effects
 	newReq := *req
-	newReq.URL = url
+	stuck := false
+
+	if rb.ss != nil {
+		cookie_url, present, err := rb.ss.GetBackend(&newReq, rb.Servers())
+
+		if err != nil {
+			rb.errHandler.ServeHTTP(w, req, err)
+			return
+		}
+
+		if present {
+			newReq.URL = cookie_url
+			stuck = true
+		}
+	}
+
+	if !stuck {
+		url, err := rb.next.NextServer()
+		if err != nil {
+			rb.errHandler.ServeHTTP(w, req, err)
+			return
+		}
+
+		if rb.ss != nil {
+			rb.ss.StickBackend(url, &w)
+		}
+
+		newReq.URL = url
+	}
 	rb.next.Next().ServeHTTP(pw, &newReq)
 
-	rb.recordMetrics(url, pw.Code, rb.clock.UtcNow().Sub(start))
+	rb.recordMetrics(newReq.URL, pw.Code, rb.clock.UtcNow().Sub(start))
 	rb.adjustWeights()
 }
 

--- a/roundrobin/rebalancer_test.go
+++ b/roundrobin/rebalancer_test.go
@@ -1,15 +1,16 @@
 package roundrobin
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/testutils"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 
 	. "gopkg.in/check.v1"
 )
@@ -325,6 +326,53 @@ func (s *RBSuite) TestRebalancerLive(c *C) {
 	c.Assert(rb.servers[0].curWeight, Equals, FSMMaxWeight)
 	c.Assert(rb.servers[1].curWeight, Equals, FSMMaxWeight)
 	c.Assert(rb.servers[2].curWeight, Equals, 1)
+}
+
+func (s *RBSuite) TestRebalancerStickySession(c *C) {
+	a, b, x := testutils.NewResponder("a"), testutils.NewResponder("b"), testutils.NewResponder("x")
+	defer a.Close()
+	defer b.Close()
+	defer x.Close()
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	lb, err := New(fwd)
+	c.Assert(err, IsNil)
+
+	rb, err := NewRebalancer(lb, RebalancerStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	rb.UpsertServer(testutils.ParseURI(a.URL))
+	rb.UpsertServer(testutils.ParseURI(b.URL))
+	rb.UpsertServer(testutils.ParseURI(x.URL))
+
+	proxy := httptest.NewServer(rb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+
+	c.Assert(rb.RemoveServer(testutils.ParseURI(a.URL)), IsNil)
+	c.Assert(seq(c, proxy.URL, 3), DeepEquals, []string{"b", "x", "b"})
+	c.Assert(rb.RemoveServer(testutils.ParseURI(b.URL)), IsNil)
+	c.Assert(seq(c, proxy.URL, 3), DeepEquals, []string{"x", "x", "x"})
 }
 
 type testMeter struct {

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -29,6 +29,13 @@ func ErrorHandler(h utils.ErrorHandler) LBOption {
 	}
 }
 
+func EnableStickySession(ss *StickySession) LBOption {
+	return func(s *RoundRobin) error {
+		s.ss = ss
+		return nil
+	}
+}
+
 type RoundRobin struct {
 	mutex      *sync.Mutex
 	next       http.Handler
@@ -37,6 +44,7 @@ type RoundRobin struct {
 	index         int
 	servers       []*server
 	currentWeight int
+	ss            *StickySession
 }
 
 func New(next http.Handler, opts ...LBOption) (*RoundRobin, error) {
@@ -45,6 +53,7 @@ func New(next http.Handler, opts ...LBOption) (*RoundRobin, error) {
 		index:   -1,
 		mutex:   &sync.Mutex{},
 		servers: []*server{},
+		ss:      nil,
 	}
 	for _, o := range opts {
 		if err := o(rr); err != nil {
@@ -61,48 +70,33 @@ func (r *RoundRobin) Next() http.Handler {
 	return r.next
 }
 
-func (r *RoundRobin) getCookieVal(req *http.Request) (*url.URL, bool, error) {
-	// Before we move on to a new server, peek at our req cookie to see if we are bound.
-	// If so, serve to them.
-	cookie, err := req.Cookie("__STICKY_SVR")
-	switch err {
-	case nil:
-	case http.ErrNoCookie:
-		return nil, false, nil
-	default:
-		return nil, false, err
-
-	}
-
-	s_url, err := url.Parse(cookie.Value)
-	if err != nil {
-		return nil, false, err
-	}
-
-	s, i := r.findServerByURL(s_url)
-	if i != -1 {
-		return s.url, true, nil
-	} else {
-		return nil, false, nil
-	}
-
-}
 func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// make shallow copy of request before chaning anything to avoid side effects
 	newReq := *req
-	cookie_url, present, err := r.getCookieVal(&newReq)
+	stuck := false
+	if r.ss != nil {
+		cookie_url, present, err := r.ss.GetBackend(&newReq, r.Servers())
 
-	if err != nil {
-		r.errHandler.ServeHTTP(w, req, err)
-		return
+		if err != nil {
+			r.errHandler.ServeHTTP(w, req, err)
+			return
+		}
+
+		if present {
+			newReq.URL = cookie_url
+			stuck = true
+		}
 	}
-	if present {
-		newReq.URL = cookie_url
-	} else {
+
+	if !stuck {
 		url, err := r.NextServer()
 		if err != nil {
 			r.errHandler.ServeHTTP(w, req, err)
 			return
+		}
+
+		if r.ss != nil {
+			r.ss.StickBackend(url, &w)
 		}
 		newReq.URL = url
 	}

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -1,0 +1,57 @@
+// package stickysession is a mixin for load balancers that implements layer 8 (http cookie) session affinity
+package roundrobin
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type StickySession struct {
+	cookiename string
+}
+
+func NewStickySession(c string) *StickySession {
+	return &StickySession{c}
+}
+
+// GetBackend returns the backend URL stored in the sticky cookie, iff the backend is still in the valid list of servers.
+func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.URL, bool, error) {
+	cookie, err := req.Cookie(s.cookiename)
+	switch err {
+	case nil:
+	case http.ErrNoCookie:
+		return nil, false, nil
+	default:
+		return nil, false, err
+	}
+
+	s_url, err := url.Parse(cookie.Value)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if s.isBackendAlive(s_url, servers) {
+		return s_url, true, nil
+	} else {
+		return nil, false, nil
+	}
+}
+
+func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
+	c := &http.Cookie{Name: s.cookiename, Value: backend.String()}
+	http.SetCookie(*w, c)
+	return
+}
+
+func (s *StickySession) isBackendAlive(needle *url.URL, haystack []*url.URL) bool {
+	if len(haystack) == 0 {
+		return false
+	}
+
+	for _, s := range haystack {
+		if sameURL(needle, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -1,4 +1,4 @@
-// package stickysession is a mixin for load balancers that implements layer 8 (http cookie) session affinity
+// package stickysession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
 package roundrobin
 
 import (

--- a/roundrobin/stickysessions_test.go
+++ b/roundrobin/stickysessions_test.go
@@ -1,0 +1,237 @@
+package roundrobin
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestSS(t *testing.T) { TestingT(t) }
+
+type SSSuite struct{}
+
+var _ = Suite(&SSSuite{})
+
+func (s *SSSuite) TestBasic(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+}
+
+func (s *SSSuite) TestStickCookie(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL)
+	c.Assert(err, IsNil)
+
+	c_out := resp.Cookies()[0]
+	c.Assert(c_out.Name, Equals, "test")
+	c.Assert(c_out.Value, Equals, a.URL)
+}
+
+func (s *SSSuite) TestRemoveRespondingServer(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+
+	lb.RemoveServer(testutils.ParseURI(a.URL))
+
+	// Now, use the organic cookie response in our next requests.
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.Cookies()[0].Name, Equals, "test")
+	c.Assert(resp.Cookies()[0].Value, Equals, b.URL)
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "b")
+	}
+}
+
+func (s *SSSuite) TestRemoveAllServers(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+
+	lb.RemoveServer(testutils.ParseURI(a.URL))
+	lb.RemoveServer(testutils.ParseURI(b.URL))
+
+	// Now, use the organic cookie response in our next requests.
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusInternalServerError)
+}
+
+func (s *SSSuite) TestBadCookieVal(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	c.Assert(err, IsNil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: "http://[::1]a"}) // error value from go's net/url tests.
+
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusInternalServerError)
+}


### PR DESCRIPTION
Bonjour @emilevauge,

This change is the same I've pushed through to vulcand/oxy(https://github.com/vulcand/oxy/pull/41) - but that hasn't been accepted, so I'll throw it over here!

I've got another PR that depends on this one for Traefik to use it, that will be coming soon...

I've not implemented this PR for the rebalancing round robin since I'm not certain how that will function... any comments are appreciated :)
