### PR TITLE
Parse the MIME media type from the Content-Type header

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -170,7 +170,13 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	utils.RemoveHeaders(w.Header(), HopHeaders...)
 	w.WriteHeader(response.StatusCode)
 
-	stream := "text/event-stream" == response.Header.Get(ContentType) || f.streamResponse
+	stream := f.streamResponse
+	if ! stream {
+		contentType, err := utils.GetHeaderMediaType(response.Header, ContentType)
+		if err == nil {
+			stream = contentType == "text/event-stream"
+		}
+	}
 	written, err := io.Copy(newResponseFlusher(w, stream), response.Body)
 
 	if req.TLS != nil {

--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -128,4 +129,10 @@ func RemoveHeaders(headers http.Header, names ...string) {
 	for _, h := range names {
 		headers.Del(h)
 	}
+}
+
+// Parse the MIME media type value of a header.
+func GetHeaderMediaType(headers http.Header, name string) (string, error)  {
+	mediatype, _, err := mime.ParseMediaType(headers.Get(name))
+	return mediatype, err
 }

--- a/utils/netutils_test.go
+++ b/utils/netutils_test.go
@@ -66,3 +66,30 @@ func (s *NetUtilsSuite) TestRemoveHeaders(c *C) {
 	c.Assert(source.Get("a"), Equals, "")
 	c.Assert(source.Get("c"), Equals, "d")
 }
+
+func (s *NetUtilsSuite) TestGetHeaderMediaType(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/event-stream")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}
+
+func (s *NetUtilsSuite) TestGetHeaderMediaTypeCharSet(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/event-stream; charset=utf-8")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}
+
+func (s *NetUtilsSuite) TestGetHeaderMediaTypeMixedCase(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/Event-Stream")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}


### PR DESCRIPTION
- Rather than just checking the raw header value
- Don't parse the header if we're streaming everything anyway
