### PR TITLE
fix log context

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -282,7 +282,7 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	defer underlyingConn.Close()
 	defer targetConn.Close()
 
-	log.Infof("Writing outgoing Websocket request to target connection: %+v", outReq)
+	ctx.log.Infof("Writing outgoing Websocket request to target connection: %+v", outReq)
 
 	// write the modified incoming request to the dialed connection
 	if err = outReq.Write(targetConn); err != nil {


### PR DESCRIPTION
The log object does not exist in this scope. Changed to use the context.