### PR TITLE
Use default TLS config instead of brand new one

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -253,7 +253,7 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 
 	if outReq.URL.Scheme == "wss" {
 		if f.TLSClientConfig == nil {
-			f.TLSClientConfig = &tls.Config{}
+			f.TLSClientConfig = http.DefaultTransport.(*http.Transport).TLSClientConfig
 		}
 		dial = func(network, address string) (net.Conn, error) {
 			return tls.Dial("tcp", host, f.TLSClientConfig)


### PR DESCRIPTION
Instead of using a new tls.Config{}, the config is fetched from http.DefaultTransport, since Traefik sets parameters into the http.DefaultTransport: https://github.com/containous/traefik/blob/master/traefik.go#L179

Without this fix Traefik config parameters like InsecureSkipVerify does not work for WebSockets.