### PR TITLE
Fix forward routing issue

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -238,10 +238,18 @@ func (f *httpForwarder) copyRequest(req *http.Request) (*http.Request, error) {
 	outReq.URL.Scheme = req.URL.Scheme
 	outReq.URL.Host = req.URL.Host
 
-	// RequestURI contains the originally requested path and query string. We have to copy this to the outgoing request
-	u, err := url.ParseRequestURI(req.RequestURI)
-	if err != nil {
-		return nil, err
+	// If the Request was created by Go via a real HTTP request,  RequestURI will
+	// contain the original query string. If the Request was created in code, RequestURI
+	// will be empty, and we will use the URL object instead
+	var u *url.URL
+	if req.RequestURI != "" {
+		var err error
+		u, err = url.ParseRequestURI(req.RequestURI)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		u = req.URL
 	}
 	outReq.URL.Path = u.Path
 	outReq.URL.RawPath = u.RawPath

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -380,3 +380,23 @@ func (s *FwdSuite) TestTrailer(c *C) {
 	c.Assert(resp.Trailer["Announced"][0], Equals, "value 1")
 	c.Assert(resp.Trailer["Unannounced"][0], Equals, "value 2")
 }
+
+func (s *FwdSuite) TestDirectServeHTTP(c *C) {
+	f, err := New()
+	c.Assert(err, IsNil)
+
+	called := false
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		called = true
+		w.Write([]byte("hello"))
+	})
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	c.Assert(err, IsNil)
+
+	// Directly call the http handler with a created request
+	resp := httptest.NewRecorder()
+	f.ServeHTTP(resp, req)
+	c.Assert(called, Equals, true)
+}

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -205,10 +205,10 @@ func (s *FwdSuite) TestCustomLogger(c *C) {
 	c.Assert(strings.Contains(buf.String(), srv.URL), Equals, true)
 }
 
-func (s *FwdSuite) TestEscapedURL(c *C) {
-	var outURL string
+func (s *FwdSuite) TestRouteForwarding(c *C) {
+	var outPath string
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
-		outURL = req.RequestURI
+		outPath = req.RequestURI
 		w.Write([]byte("hello"))
 	})
 	defer srv.Close()
@@ -222,16 +222,32 @@ func (s *FwdSuite) TestEscapedURL(c *C) {
 	})
 	defer proxy.Close()
 
-	path := "/log/http%3A%2F%2Fwww.site.com%2Fsomething?a=b"
+	tests := []struct {
+		Path  string
+		Query string
 
-	request, err := http.NewRequest("GET", proxy.URL, nil)
-	parsed := testutils.ParseURI(proxy.URL)
-	parsed.Opaque = path
-	request.URL = parsed
-	re, err := http.DefaultClient.Do(request)
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
-	c.Assert(outURL, Equals, path)
+		ExpectedPath string
+	}{
+		{"/hello", "", "/hello"},
+		{"//hello", "", "//hello"},
+		{"///hello", "", "///hello"},
+		{"/hello", "abc=def&def=123", "/hello?abc=def&def=123"},
+		{"/log/http%3A%2F%2Fwww.site.com%2Fsomething?a=b", "", "/log/http%3A%2F%2Fwww.site.com%2Fsomething?a=b"},
+	}
+
+	for _, test := range tests {
+		proxyURL := proxy.URL + test.Path
+		if test.Query != "" {
+			proxyURL = proxyURL + "?" + test.Query
+		}
+		request, err := http.NewRequest("GET", proxyURL, nil)
+		c.Assert(err, IsNil)
+
+		re, err := http.DefaultClient.Do(request)
+		c.Assert(err, IsNil)
+		c.Assert(re.StatusCode, Equals, http.StatusOK)
+		c.Assert(outPath, Equals, test.ExpectedPath)
+	}
 }
 
 func (s *FwdSuite) TestForwardedProto(c *C) {


### PR DESCRIPTION
Forward is currently not passing the path correctly to the backend server.

The cause seems to be the use of `url.URL.Opaque` when modifying the incoming request object, and passing it to the backend server.

## Minimal Reproducible Test Case

server.go
```golang
package main

import (
	"fmt"
	"log"
	"net/http"

	"github.com/containous/oxy/forward"
	"github.com/containous/oxy/testutils"
)

func main() {
	// Backend server
	go func() {
		http.ListenAndServe(":3000", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			//requestDump, _ := httputil.DumpRequest(r, true)
		        //log.Println("[Backend]", string(requestDump))
			log.Println("[Backend] Path:", r.URL.String())
			//log.Println("[Backend] Query:", r.URL.Query())
			fmt.Fprintf(w, "ok")
		}))
	}()

	fwd, _ := forward.New()
	s := &http.Server{
		Addr: ":8000",
		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
			req.URL = testutils.ParseURI("http://localhost:3000")
			fwd.ServeHTTP(w, req)
		}),
	}
	log.Println(s.ListenAndServe())
}
```

### Output
```bash
$ go run server.go
$ curl localhost:8000//google.com
2017/10/27 10:31:51 [Backend] Path: http://google.com
```

### Expected Output
```bash
$ go run server.go
$ curl localhost:8000//google.com
2017/10/27 10:31:51 [Backend] Path: //google.com
```

## Related traefik issues

containous/traefik#1323
containous/traefik#1966