### PR TITLE
Disable websocket compression

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -283,8 +283,6 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 
 	dialer := websocket.DefaultDialer
 
-	dialer.EnableCompression = strings.Contains(req.Header.Get("Sec-Websocket-Extensions"), "permessage-deflate")
-
 	if outReq.URL.Scheme == "wss" && f.tlsClientConfig != nil {
 		dialer.TLSClientConfig = f.tlsClientConfig.Clone()
 		// WebSocket is only in http/1.1
@@ -325,8 +323,6 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool {
 		return true
 	}}
-
-	upgrader.EnableCompression = strings.Contains(resp.Header.Get("Sec-Websocket-Extensions"), "permessage-deflate")
 
 	utils.RemoveHeaders(resp.Header, WebsocketUpgradeHeaders...)
 


### PR DESCRIPTION
WebSocket compression with gorilla failed if server do not manage `server_no_context_takeover` and `client_no_context_takeover`.
That's why for now we will disable compression

related to: https://github.com/containous/traefik/issues/2714